### PR TITLE
Make highlighting matching nodes work again

### DIFF
--- a/contrib/pmltq/tree_query.mak
+++ b/contrib/pmltq/tree_query.mak
@@ -467,7 +467,7 @@ DeclareMinorMode 'PMLTQ_Results' => {
   post_hooks => {
     node_style_hook => sub {
       my ($node,$styles)=@_;
-      my $m=$PMLTQ::is_match{$node->{id}};
+      my $m=$PMLTQ::is_match{$node};
       if (first { $node==$_->[0] } @marked_nodes) {
 	AddStyle($styles,'Oval',-fill => 'orange');
 	AddStyle($styles,'Node',-addwidth=>4);


### PR DESCRIPTION
The %PMLTQ::is_match uses object reference addresses as keys. It's
probably wrong and we should replace them by node ids, so the original
code was right - but we need to change the logic everywhere, not just
in one place.